### PR TITLE
Ability to overwrite existing smarty plugins

### DIFF
--- a/vt-smartyext/oxutilsview_vtse.php
+++ b/vt-smartyext/oxutilsview_vtse.php
@@ -20,7 +20,7 @@ class oxutilsview_vtse extends oxutilsview_vtse_parent
 		$cfg = oxRegistry::getConfig();
 
 		$aPluginsDir = $oSmarty->plugins_dir;
-		$aPluginsDir[] = $cfg->getModulesDir()."/vt-smartyext/smarty/";
+		array_unshift($aPluginsDir, $cfg->getModulesDir()."/vt-smartyext/smarty/");
 
 		$oSmarty->plugins_dir = $aPluginsDir;
 	}


### PR DESCRIPTION
When you put the module's smarty directory in front of the plugins_dir array, it will have precedence over existing modules. Then it's possible to overwrite existing smarty plugins, e.g. oxmultilang or oxprice.
